### PR TITLE
Code refactor to match the new event-reader api contract

### DIFF
--- a/event_reader_service.go
+++ b/event_reader_service.go
@@ -8,13 +8,14 @@ import (
 	"net/http"
 	"strconv"
 
+	"fmt"
 	"github.com/Financial-Times/go-logger"
 )
 
 const (
-	uuidPathVar      = "uuid"
-	intervalPathVar  = "interval"
-	lastEventPathVar = "lastEvent"
+	uuidPathVar         = "uuid"
+	earliestTimePathVar = "earliestTime"
+	lastEventPathVar    = "lastEvent"
 )
 
 type EventReader interface {
@@ -31,7 +32,7 @@ func (ser SplunkEventReader) GetLatestEvent(contentType string, lookbackPeriod s
 	req, err := http.NewRequest("GET", ser.eventReaderAddress+"/"+contentType+"/events", nil)
 
 	q := req.URL.Query()
-	q.Add(intervalPathVar, lookbackPeriod)
+	q.Add(earliestTimePathVar, fmt.Sprintf("-%s", lookbackPeriod))
 	q.Add(lastEventPathVar, strconv.FormatBool(true))
 	req.URL.RawQuery = q.Encode()
 
@@ -75,7 +76,7 @@ func (ser SplunkEventReader) GetTransactions(contentType string, lookbackPeriod 
 	return ser.GetTransactionsForUUIDs(contentType, nil, lookbackPeriod)
 }
 
-func (ser SplunkEventReader) GetTransactionsForUUIDs(contentType string, uuids []string, interval string) (transactions, error) {
+func (ser SplunkEventReader) GetTransactionsForUUIDs(contentType string, uuids []string, earliestTime string) (transactions, error) {
 
 	req, err := http.NewRequest("GET", ser.eventReaderAddress+"/"+contentType+"/transactions", nil)
 	q := req.URL.Query()
@@ -84,7 +85,7 @@ func (ser SplunkEventReader) GetTransactionsForUUIDs(contentType string, uuids [
 			q.Add(uuidPathVar, uuid)
 		}
 	}
-	q.Add(intervalPathVar, interval)
+	q.Add(earliestTimePathVar, fmt.Sprintf("-%s", earliestTime))
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := http.DefaultClient.Do(req)

--- a/event_reader_service_test.go
+++ b/event_reader_service_test.go
@@ -17,7 +17,7 @@ func TestGetLatestEvent_ServerErrors(t *testing.T) {
 
 	eventReaderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, fmt.Sprintf("/%s/events", strings.ToLower(contentType)), r.URL.Path)
-		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s", intervalPathVar, "60m", lastEventPathVar, "true"), r.URL.RawQuery)
+		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s", earliestTimePathVar, "-60m", lastEventPathVar, "true"), r.URL.RawQuery)
 
 		w.WriteHeader(http.StatusInternalServerError)
 
@@ -36,7 +36,7 @@ func TestGetLatestEvent_ServerErrors(t *testing.T) {
 	//log message format
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "Failed to retrieve latest log event", hook.LastEntry().Message)
-	assert.Equal(t, fmt.Sprintf("%s/%s/events?interval=60m\u0026lastEvent=true", eventReaderServer.URL, strings.ToLower(contentType)), hook.LastEntry().Data["url"])
+	assert.Equal(t, fmt.Sprintf("%s/%s/events?%s=-60m\u0026lastEvent=true", eventReaderServer.URL, strings.ToLower(contentType), earliestTimePathVar), hook.LastEntry().Data["url"])
 }
 
 func TestGetLatestEvent_5xx(t *testing.T) {
@@ -60,7 +60,7 @@ func TestGetLatestEvent_5xx(t *testing.T) {
 	//log message format
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "Failed to retrieve latest log event", hook.LastEntry().Message)
-	assert.Equal(t, fmt.Sprintf("%s/%s/events?interval=60m\u0026lastEvent=true", eventReaderServer.URL, strings.ToLower(contentType)), hook.LastEntry().Data["url"])
+	assert.Equal(t, fmt.Sprintf("%s/%s/events?%s=-60m\u0026lastEvent=true", eventReaderServer.URL, strings.ToLower(contentType), earliestTimePathVar), hook.LastEntry().Data["url"])
 }
 
 func TestGetLatestEvent_UnmarshallingError(t *testing.T) {
@@ -69,7 +69,7 @@ func TestGetLatestEvent_UnmarshallingError(t *testing.T) {
 
 	eventReaderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, fmt.Sprintf("/%s/events", strings.ToLower(contentType)), r.URL.Path)
-		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s", intervalPathVar, "60m", lastEventPathVar, "true"), r.URL.RawQuery)
+		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s", earliestTimePathVar, "-60m", lastEventPathVar, "true"), r.URL.RawQuery)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("Wrong body format"))
@@ -89,7 +89,7 @@ func TestGetLatestEvent_UnmarshallingError(t *testing.T) {
 	//log message format
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "Error unmarshalling latest publish event message", hook.LastEntry().Message)
-	assert.Equal(t, fmt.Sprintf("%s/%s/events?interval=60m\u0026lastEvent=true", eventReaderServer.URL, strings.ToLower(contentType)), hook.LastEntry().Data["url"])
+	assert.Equal(t, fmt.Sprintf("%s/%s/events?%s=-60m\u0026lastEvent=true", eventReaderServer.URL, strings.ToLower(contentType), earliestTimePathVar), hook.LastEntry().Data["url"])
 }
 
 func TestGetLatestEvent_Success(t *testing.T) {
@@ -98,7 +98,7 @@ func TestGetLatestEvent_Success(t *testing.T) {
 
 	eventReaderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, fmt.Sprintf("/%s/events", strings.ToLower(contentType)), r.URL.Path)
-		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s", intervalPathVar, "60m", lastEventPathVar, "true"), r.URL.RawQuery)
+		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s", earliestTimePathVar, "-60m", lastEventPathVar, "true"), r.URL.RawQuery)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("{}"))
@@ -123,7 +123,7 @@ func TestGetTransactionsForUUIDs_UnmarshallingError(t *testing.T) {
 
 	eventReaderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, fmt.Sprintf("/%s/transactions", strings.ToLower(contentType)), r.URL.Path)
-		assert.Equal(t, fmt.Sprintf("%s=%s", intervalPathVar, "60m"), r.URL.RawQuery)
+		assert.Equal(t, fmt.Sprintf("%s=%s", earliestTimePathVar, "-60m"), r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("Wrong body format"))
 	}))
@@ -141,7 +141,7 @@ func TestGetTransactionsForUUIDs_UnmarshallingError(t *testing.T) {
 	//log message format
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "Error unmarshalling transaction log messages", hook.LastEntry().Message)
-	assert.Equal(t, fmt.Sprintf("%s/%s/transactions?interval=60m", eventReaderServer.URL, strings.ToLower(contentType)), hook.LastEntry().Data["url"])
+	assert.Equal(t, fmt.Sprintf("%s/%s/transactions?%s=-60m", eventReaderServer.URL, strings.ToLower(contentType), earliestTimePathVar), hook.LastEntry().Data["url"])
 }
 
 func TestGetTransactionsForUUIDs_ServerErrors(t *testing.T) {
@@ -165,7 +165,7 @@ func TestGetTransactionsForUUIDs_ServerErrors(t *testing.T) {
 	//log message format
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "Failed to retrieve transactions", hook.LastEntry().Message)
-	assert.Equal(t, fmt.Sprintf("%s/%s/transactions?interval=60m", eventReaderServer.URL, strings.ToLower(contentType)), hook.LastEntry().Data["url"])
+	assert.Equal(t, fmt.Sprintf("%s/%s/transactions?%s=-60m", eventReaderServer.URL, strings.ToLower(contentType), earliestTimePathVar), hook.LastEntry().Data["url"])
 }
 
 func TestGetTransactionsForUUIDs_5xx(t *testing.T) {
@@ -174,7 +174,7 @@ func TestGetTransactionsForUUIDs_5xx(t *testing.T) {
 
 	eventReaderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, fmt.Sprintf("/%s/transactions", strings.ToLower(contentType)), r.URL.Path)
-		assert.Equal(t, fmt.Sprintf("%s=%s", intervalPathVar, "60m"), r.URL.RawQuery)
+		assert.Equal(t, fmt.Sprintf("%s=%s", earliestTimePathVar, "-60m"), r.URL.RawQuery)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer eventReaderServer.Close()
@@ -191,7 +191,7 @@ func TestGetTransactionsForUUIDs_5xx(t *testing.T) {
 	//log message format
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "Failed to retrieve transactions", hook.LastEntry().Message)
-	assert.Equal(t, fmt.Sprintf("%s/%s/transactions?interval=60m", eventReaderServer.URL, strings.ToLower(contentType)), hook.LastEntry().Data["url"])
+	assert.Equal(t, fmt.Sprintf("%s/%s/transactions?%s=-60m", eventReaderServer.URL, strings.ToLower(contentType), earliestTimePathVar), hook.LastEntry().Data["url"])
 }
 
 func TestGetTransactionsForUUIDs_Success(t *testing.T) {
@@ -199,7 +199,7 @@ func TestGetTransactionsForUUIDs_Success(t *testing.T) {
 	hook := logger.NewTestHook("annotations-monitoring-service")
 	eventReaderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, fmt.Sprintf("/%s/transactions", strings.ToLower(contentType)), r.URL.Path)
-		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s&%s=%s", intervalPathVar, "60m", uuidPathVar, "uuid1", uuidPathVar, "uuid2"), r.URL.RawQuery)
+		assert.Equal(t, fmt.Sprintf("%s=%s&%s=%s&%s=%s", earliestTimePathVar, "-60m", uuidPathVar, "uuid1", uuidPathVar, "uuid2"), r.URL.RawQuery)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("[]"))
 	}))
@@ -221,7 +221,7 @@ func TestGetTransactions_Success(t *testing.T) {
 	hook := logger.NewTestHook("annotations-monitoring-service")
 	eventReaderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, fmt.Sprintf("/%s/transactions", strings.ToLower(contentType)), r.URL.Path)
-		assert.Equal(t, fmt.Sprintf("%s=%s", intervalPathVar, "60m"), r.URL.RawQuery)
+		assert.Equal(t, fmt.Sprintf("%s=%s", earliestTimePathVar, "-60m"), r.URL.RawQuery)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("[]"))

--- a/monitoring_service.go
+++ b/monitoring_service.go
@@ -50,17 +50,9 @@ func (s AnnotationsMonitoringService) CloseCompletedTransactions() {
 	for _, tx := range txs {
 
 		var startTime, endTime, isValid string
-		isAnnotationEvent := false
-
 		for _, event := range tx.Events {
-			// identify the annotation events
-			if event.ContentType == contentType {
-				isAnnotationEvent = true
-			}
-
 			// find start or end event
-			// TODO: contentType check can be removed when VIDEO changes are also implemented
-			if event.Event == startEvent && event.ContentType == "Annotations" {
+			if event.Event == startEvent {
 				startTime = event.Time
 			} else if event.Event == completenessCriteriaEvent && event.Level == infoLevel {
 				endTime = event.Time
@@ -77,7 +69,7 @@ func (s AnnotationsMonitoringService) CloseCompletedTransactions() {
 		}
 
 		// if it is not a completed and valid annotation transaction: ignore it
-		if !isAnnotationEvent || startTime == "" || endTime == "" || isValid == "" {
+		if startTime == "" || endTime == "" || isValid == "" {
 			continue
 		}
 


### PR DESCRIPTION
To match the [splunk-event-reader changes](https://github.com/Financial-Times/splunk-event-reader/pull/4)