### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Annotations Monitoring Service
 
 This service is responsible for monitoring annotation publishes.
@@ -8,7 +12,7 @@ annotations-monitoring-service
 
 ## Primary URL
 
-<https://upp-prod-delivery-glb.upp.ft.com/__annotations-monitoring-service>
+https://upp-prod-delivery-glb.upp.ft.com/__annotations-monitoring-service
 
 ## Service Tier
 
@@ -17,22 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- ivan.nikolov
-- marina.chompalova
-- miroslav.gatsanoga
-- kalin.arsov
 
 ## Host Platform
 
@@ -43,13 +31,15 @@ AWS
 The annotations monitoring service is responsible for closing (logging a PublishEnd event for) completed transactions when publishing an annotation.
 The basic algorithm is:
 
-        every 5 minutes repeat {
-                1) call splunk-event-reader to determine the lookbackPeriod (last successful PublishEnd event)
-                2) call splunk-event-reader to receive all the open annotations transactions for the lookbackPeriod (transactions with no PublishEnd event)
-                3) close completed transactions (valid annotation messages with successful Neo4j write event)
-                4) call splunk-event-reader to receive earlier unclosed transactions - check for lookbackPeriod + supersededLookbackPeriod
-                5) close events that have been superseded by recent publishes
-        }
+```
+    every 5 minutes repeat {
+            1) call splunk-event-reader to determine the lookbackPeriod (last successful PublishEnd event)
+            2) call splunk-event-reader to receive all the open annotations transactions for the lookbackPeriod (transactions with no PublishEnd event)
+            3) close completed transactions (valid annotation messages with successful Neo4j write event)
+            4) call splunk-event-reader to receive earlier unclosed transactions - check for lookbackPeriod + supersededLookbackPeriod
+            5) close events that have been superseded by recent publishes
+    }
+```
 
 ## Contains Personal Data
 
@@ -59,9 +49,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- splunk-event-reader
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -99,6 +99,14 @@ Manual
 
 The release is triggered by making a Github release which is then picked up by a Jenkins multibranch pipeline. The Jenkins pipeline should be manually started in order to deploy the helm package to the Kubernetes clusters.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 NotApplicable
@@ -110,8 +118,9 @@ There is no key rotation procedure for this system.
 ## Monitoring
 
 Look for the pods in the cluster health endpoint and click to see pod health and checks:
-- <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=annotations-monitoring-service>
-- <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=annotations-monitoring-service>
+
+*   <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=annotations-monitoring-service>
+*   <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=annotations-monitoring-service>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/annotations-monitoring-service/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **annotations-monitoring-service** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **annotations-monitoring-service** system in [Biz Ops](https://biz-ops.in.ft.com/System/annotations-monitoring-service).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
